### PR TITLE
Fix key highlighting in BG and Mono variants

### DIFF
--- a/themes/alabaster-color-theme.json
+++ b/themes/alabaster-color-theme.json
@@ -1031,7 +1031,7 @@
             "font_weight": null
           },
           "property": {
-            "color": "#000000",
+            "color": "#010409ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2117,7 +2117,7 @@
             "font_weight": null
           },
           "property": {
-            "color": "#000000",
+            "color": "#010409ff",
             "font_style": null,
             "font_weight": null
           },

--- a/themes/alabaster-color-theme.json
+++ b/themes/alabaster-color-theme.json
@@ -757,6 +757,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "property": {
+            "color": "#000000",
+            "font_style": null,
+            "font_weight": null
+          },
           "type.class.definition": {
             "color": "#000000",
             "background_color": "#eeeeee",
@@ -1022,6 +1027,11 @@
           "constant": {
             "color": "#000000",
             "background_color": "#eeeeee",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#000000",
             "font_style": null,
             "font_weight": null
           },
@@ -1834,6 +1844,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "property": {
+            "color": "#000000",
+            "font_style": null,
+            "font_weight": null
+          },
           "type.class.definition": {
             "color": "#000000",
             "background_color": "#dbf1ff",
@@ -2098,6 +2113,11 @@
           },
           "constant": {
             "color": "#7a3e9d",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#000000",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
Before this PR, opening a YAML file in any BG or Mono variant highlighted both keys and values with the same background color, making the entire file look uniformly highlighted. Keys now display without background, only string values, comments, and typed constructs get their respective tinted backgrounds.

## Before

<img width="2672" height="1441" alt="Screenshot 2026-06-02 at 14 28 35" src="https://github.com/user-attachments/assets/53d71316-caa8-4e02-a73f-a6859853ac8f" />


## After

<img width="2560" height="1329" alt="Screenshot 2026-06-02 at 14 28 48" src="https://github.com/user-attachments/assets/16fbef47-0040-497d-9a2e-ea2717333be1" />
